### PR TITLE
Make "checked" attribute a little nicer to use

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function elemFromExpr (expr, document = mydocument, HTMLElement = myElement) {
     elem = subelem
   }
   for (const [k, v] of Object.entries(props)) {
-    if (k.startsWith('on')) {
+    if (k.startsWith('on') || k == 'checked') {
       elem[k] = v
     } else {
       elem.setAttribute(k, v)

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function elemFromExpr (expr, document = mydocument, HTMLElement = myElement) {
     elem = subelem
   }
   for (const [k, v] of Object.entries(props)) {
-    if (k.startsWith('on') || k == 'checked') {
+    if (k.startsWith('on') || k == 'checked' || k == 'disabled') {
       elem[k] = v
     } else {
       elem.setAttribute(k, v)


### PR DESCRIPTION
Hi! Here's a very small change I made to make working with HTML [boolean attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes) `checked` and `disabled` a bit less messy on the calling side. 

Without this change, if you alchemize:

```
['input', {type: 'checkbox', checked: false}]
```

you get a checked box, which is surprising.

I was doing some stuff with `Object.assign()` to change whether I pass the `checked` key in based on the value, but that was messy. So with this small change, things behave a bit more as expected: setting the `checked` property to something falsey like `null`, `false`, `undefined`, or `0` results in an unchecked box.

Please feel welcome to merge it or just take as a feature suggestion, if you like. I really love html-alchemist and [your very thorough blog post introducing witch-clock and how it uses alchemist](https://blog.bovid.space/witch-clock). Thank you so much for these great words and tools!

Cheers

p.s. I hate generative AI and didn't use it for this PR, or for anything else ever, not even once